### PR TITLE
Fix error regarding librarian clean command

### DIFF
--- a/pulet
+++ b/pulet
@@ -112,7 +112,7 @@ install_modules(){
 # private
 clean_modules(){
   echo "Clean puppet modules" >&2
-  librarian clean --path ./modules --verbose
+  librarian clean --verbose
 }
 
 SUBCOMMANDS[librarian]="    librarian-puppet"


### PR DESCRIPTION
When executing `pulet` there's an error message saying:

```
...
ERROR: "librarian-puppet clean" was called with arguments ["--path", "./modules"]
Usage: "librarian-puppet clean"
...
```

This change resolves that error message. Please note that I haven't clarified if this is version dependent.